### PR TITLE
feature/TeamModePlayerSelect

### DIFF
--- a/PugSharp.Config/TeamMode.cs
+++ b/PugSharp.Config/TeamMode.cs
@@ -7,4 +7,7 @@ public enum TeamMode
 
     // Scramble Teams after all players are joined
     Scramble,
+
+    // Player Selects which Team to join
+    PlayerSelect
 }

--- a/PugSharp.Match/Match.cs
+++ b/PugSharp.Match/Match.cs
@@ -672,6 +672,11 @@ public class Match : IDisposable
                     }
                 }
 
+                if (!_ReadyReminderTimer.Enabled)
+                {
+                    return;
+                }
+
                 _Logger.LogInformation("ReadyReminder Elapsed");
                 var readyPlayerIds = AllMatchPlayers.Where(p => p.IsReady).Select(x => x.Player.SteamID).ToList();
                 var notReadyPlayers = _CsServer.LoadAllPlayers().Where(p => !readyPlayerIds.Contains(p.SteamID));

--- a/PugSharp.Match/Match.cs
+++ b/PugSharp.Match/Match.cs
@@ -680,8 +680,8 @@ public class Match : IDisposable
                 _Logger.LogInformation("ReadyReminder Elapsed");
                 var readyPlayerIds = AllMatchPlayers.Where(p => p.IsReady).Select(x => x.Player.SteamID).ToList();
                 var notReadyPlayers = _CsServer.LoadAllPlayers().Where(p => !readyPlayerIds.Contains(p.SteamID));
-                var remindMessage = _TextHelper.GetText(nameof(Resources.PugSharp_Match_RemindReady));
 
+                var remindMessage = _TextHelper.GetText(nameof(Resources.PugSharp_Match_RemindReady));
                 foreach (var player in notReadyPlayers)
                 {
                     player.PrintToChat(remindMessage);

--- a/PugSharp.Match/Match.cs
+++ b/PugSharp.Match/Match.cs
@@ -124,6 +124,7 @@ public class Match : IDisposable
         _MatchStateMachine.Configure(MatchState.DefineTeams)
             .Permit(MatchCommand.TeamsDefined, MatchState.MapVote)
             .OnEntry(ContinueIfDefault)
+            .OnEntry(ContinueIfPlayerSelect)
             .OnEntry(ScrambleTeams);
 
         _MatchStateMachine.Configure(MatchState.MapVote)
@@ -209,7 +210,15 @@ public class Match : IDisposable
 
     private void ContinueIfDefault()
     {
-        if (MatchInfo.Config.TeamMode == Config.TeamMode.Default || MatchInfo.Config.TeamMode == Config.TeamMode.PlayerSelect)
+        if (MatchInfo.Config.TeamMode == Config.TeamMode.Default)
+        {
+            TryFireState(MatchCommand.TeamsDefined);
+        }
+    }
+
+    private void ContinueIfPlayerSelect()
+    {
+        if (MatchInfo.Config.TeamMode == Config.TeamMode.PlayerSelect)
         {
             TryFireState(MatchCommand.TeamsDefined);
         }

--- a/PugSharp.Translation/Properties/Resources.Designer.cs
+++ b/PugSharp.Translation/Properties/Resources.Designer.cs
@@ -601,6 +601,15 @@ namespace PugSharp.Translation.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are currently on the Team {0:teamName}.
+        /// </summary>
+        public static string PugSharp_Match_TeamReminder {
+            get {
+                return ResourceManager.GetString("PugSharp.Match.TeamReminder", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to You are !!not!! ready! Type `!ready` if you are ready..
         /// </summary>
         public static string PugSharp_Match_RemindReady {
@@ -608,7 +617,7 @@ namespace PugSharp.Translation.Properties {
                 return ResourceManager.GetString("PugSharp.Match.RemindReady", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0:teamName} selected {1:side} as startside!.
         /// </summary>
@@ -651,6 +660,15 @@ namespace PugSharp.Translation.Properties {
         public static string PugSharp_Match_VoteTeamMenuHeader {
             get {
                 return ResourceManager.GetString("PugSharp.Match.VoteTeamMenuHeader", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar Confirming Team
+        /// </summary>
+        public static string PugSharp_Match_VoteConfirmTeamHeader {
+            get {
+                return ResourceManager.GetString("PugSharp.Match.VoteConfirmTeamHeader", resourceCulture);
             }
         }
         

--- a/PugSharp.Translation/Properties/Resources.br.resx
+++ b/PugSharp.Translation/Properties/Resources.br.resx
@@ -238,6 +238,9 @@
   <data name="PugSharp.Match.Info.WaitingForAllPlayers" xml:space="preserve">
     <value>Aguardando todos os jogadores estarem prontos.</value>
   </data>
+  <data name="PugSharp.Match.TeamReminder" xml:space="preserve">
+    <value>Você está atualmente na equipe: **{0:teamName}**.</value>
+  </data>
   <data name="PugSharp.Match.RemindReady" xml:space="preserve">
     <value>Você !!não!! está pronto!! Digite `!ready` se você está pronto.</value>
   </data>
@@ -255,6 +258,9 @@
   </data>
   <data name="PugSharp.Match.VoteTeamMenuHeader" xml:space="preserve">
     <value>Escolha o lado inicial com (`!stay` ou `!switch`)</value>
+  </data>
+  <data name="PugSharp_Match_VoteConfirmTeamHeader" xml:space="preserve">
+    <value>Escolha a equipe correta:</value>
   </data>
   <data name="PugSharp.Match.WaitForOtherTeam" xml:space="preserve">
     <value>Aguardando o voto da outra equipe!</value>

--- a/PugSharp.Translation/Properties/Resources.da.resx
+++ b/PugSharp.Translation/Properties/Resources.da.resx
@@ -70,6 +70,9 @@
   <data name="PugSharp.Command.ConfigLoaded" xml:space="preserve">
     <value>Kampconfig loadet!</value>
   </data>
+  <data name="PugSharp.Match.TeamReminder" xml:space="preserve">
+    <value>Je zit momenteel in Team: **{0:teamName}**.</value>
+  </data>
   <data name="PugSharp.Command.CreatingMatchPlayersPerTeam" xml:space="preserve">
     <value>`!spillereperteam &lt;players&gt;` for at sætte antal spillere per hold!</value>
   </data>

--- a/PugSharp.Translation/Properties/Resources.de.resx
+++ b/PugSharp.Translation/Properties/Resources.de.resx
@@ -168,6 +168,9 @@
   <data name="PugSharp.Match.Error.UnknownMapNumber" xml:space="preserve">
     <value>Die Karte mit der Kartennummer **{0:mapNumber}** ist nicht verfügbar!</value>
   </data>
+  <data name="PugSharp.Match.TeamReminder" xml:space="preserve">
+    <value>Sie sind derzeit im Team: **{0:teamName}**.</value>
+  </data>
   <data name="PugSharp.Match.RemindReady" xml:space="preserve">
     <value>Du bist !!nicht!! bereit! Schreibe `!ready` in den chat wenn du bereit bist.</value>
   </data>
@@ -176,6 +179,9 @@
   </data>
   <data name="PugSharp.Match.VoteTeamMenuHeader" xml:space="preserve">
     <value>Wähle die Startseite (`!stay` oder`!switch`)</value>
+  </data>
+  <data name="PugSharp_Match_VoteConfirmTeamHeader" xml:space="preserve">
+    <value>Wählen Sie das richtige Team:</value>
   </data>
   <data name="PugSharp.Match.VoteMapMenuHeader" xml:space="preserve">
     <value>Stimme ab um eine Karte zu bannen: schreibe `!&lt;Kartennummer&gt;` in den Chat</value>

--- a/PugSharp.Translation/Properties/Resources.es.resx
+++ b/PugSharp.Translation/Properties/Resources.es.resx
@@ -64,6 +64,9 @@
   <data name="PugSharp.Match.VoteTeamMenuHeader" xml:space="preserve">
     <value>Elige bando inicial:</value>
   </data>
+  <data name="PugSharp_Match_VoteConfirmTeamHeader" xml:space="preserve">
+    <value>Elige el equipo correcto:</value>
+  </data>
   <data name="PugSharp.Match.VoteMapMenuHeader" xml:space="preserve">
     <value>Votación para banear mapa: escribe `!&lt;mapnumber&gt;`</value>
   </data>
@@ -87,6 +90,9 @@
   </data>
   <data name="PugSharp.Match.Info.WaitingForAllPlayers" xml:space="preserve">
     <value>Esperando a que todos los jugadores estén preparados.</value>
+  </data>
+  <data name="PugSharp.Match.TeamReminder" xml:space="preserve">
+    <value>Actualmente estás en el equipo: **{0:teamName}**.</value>
   </data>
   <data name="PugSharp.Match.Info.IsLive" xml:space="preserve">
     <value>La partida está **EN VIVO**</value>

--- a/PugSharp.Translation/Properties/Resources.ja.resx
+++ b/PugSharp.Translation/Properties/Resources.ja.resx
@@ -67,6 +67,9 @@
   <data name="PugSharp.Command.ChangedMaxRounds" xml:space="preserve">
     <value>最大ラウンド数を{0:oldMaxRounds}から{1:maxRounds}に変更</value>
   </data>
+  <data name="PugSharp.Match.TeamReminder" xml:space="preserve">
+    <value>あなたは現在次のチームに所属しています: **{0:teamName}**.</value>
+  </data>
   <data name="PugSharp.Command.CreatingMatchStartMatch" xml:space="preserve">
     <value>`!startmatch`で試合を開始できます！</value>
   </data>

--- a/PugSharp.Translation/Properties/Resources.ko.resx
+++ b/PugSharp.Translation/Properties/Resources.ko.resx
@@ -58,6 +58,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="PugSharp.Match.TeamReminder" xml:space="preserve">
+    <value>귀하는 현재 다음 팀에 속해 있습니다: **{0:teamName}**.</value>
+  </data>
   <data name="PugSharp.Hello" xml:space="preserve">
     <value>**{0:playerName}** 안녕하세요,
 매치에 오신걸 환영합니다 {1:matchId}</value>

--- a/PugSharp.Translation/Properties/Resources.resx
+++ b/PugSharp.Translation/Properties/Resources.resx
@@ -297,6 +297,9 @@
   <data name="PugSharp.Match.Info.WaitingForAllPlayers" xml:space="preserve">
     <value>Waiting for all players to be ready.</value>
   </data>
+  <data name="PugSharp.Match.TeamReminder" xml:space="preserve">
+    <value>You are currently on Team: **{0:teamName}**.</value>
+  </data>
   <data name="PugSharp.Match.RemindReady" xml:space="preserve">
     <value>You are !!not!! ready! Type `!ready` if you are ready.</value>
   </data>
@@ -314,6 +317,9 @@
   </data>
   <data name="PugSharp.Match.VoteTeamMenuHeader" xml:space="preserve">
     <value>Choose starting side (`!stay` or `!switch`)</value>
+  </data>
+  <data name="PugSharp.Match.VoteConfirmTeamHeader" xml:space="preserve">
+    <value>Escolha a equipe correta:</value>
   </data>
   <data name="PugSharp.Match.WaitForOtherTeam" xml:space="preserve">
     <value>Waiting for other Team to vote!</value>

--- a/PugSharp/Application.cs
+++ b/PugSharp/Application.cs
@@ -338,12 +338,12 @@ public class Application : IApplication
             if (_Match.CurrentState is MatchState.WaitingForPlayersConnectedReady or MatchState.WaitingForPlayersReady)
             {
                 _CsServer.LoadAndExecuteConfig("warmup.cfg");
-            }
 
-            _Dispatcher.NextFrame(() =>
-            {
-                SetMatchVariable();
-            });
+                _Dispatcher.NextFrame(() =>
+                {
+                    SetMatchVariable();
+                });
+            }
         }
     }
 

--- a/PugSharp/Application.cs
+++ b/PugSharp/Application.cs
@@ -267,7 +267,7 @@ public class Application : IApplication
             if (_Match.MatchInfo.Config.TeamMode == TeamMode.PlayerSelect)
             {
                 // If player is already on team, make sure the match teams are updated
-                if (_Match.PlayerIsReady(playerController.SteamID))
+                if (_Match.PlayerIsReady(playerController.SteamID) && (team == (int)Match.Contract.Team.Terrorist || team == (int)Match.Contract.Team.CounterTerrorist))
                 {
                     _Match.TryAddPlayer(new Player(playerController.SteamID));
                 }
@@ -335,6 +335,11 @@ public class Application : IApplication
     {
         if (_Match != null)
         {
+            if (_Match.CurrentState is MatchState.WaitingForPlayersConnectedReady or MatchState.WaitingForPlayersReady)
+            {
+                _CsServer.LoadAndExecuteConfig("warmup.cfg");
+            }
+
             _Dispatcher.NextFrame(() =>
             {
                 SetMatchVariable();
@@ -1970,13 +1975,13 @@ public class Application : IApplication
         // Allow players to select their team
         if (_Match.MatchInfo.Config.TeamMode == TeamMode.PlayerSelect)
         {
-            _CsServer.UpdateConvar("sv_disable_teamselect_menu", value: false);
-            _CsServer.UpdateConvar("sv_human_autojoin_team", Match.Contract.Team.Spectator);
+            _CsServer.UpdateConvar("sv_disable_teamselect_menu", false);
+            _CsServer.UpdateConvar("sv_human_autojoin_team", (int)Match.Contract.Team.None);
         }
         else
         {
-            _CsServer.UpdateConvar("sv_disable_teamselect_menu", value: true);
-            _CsServer.UpdateConvar("sv_human_autojoin_team", Match.Contract.Team.Terrorist);
+            _CsServer.UpdateConvar("sv_disable_teamselect_menu", true);
+            _CsServer.UpdateConvar("sv_human_autojoin_team", (int)Match.Contract.Team.Terrorist);
         }
 
         _Logger.LogInformation("Set match variables done");

--- a/PugSharp/Application.cs
+++ b/PugSharp/Application.cs
@@ -1897,7 +1897,7 @@ public class Application : IApplication
                 {
                     try
                     {
-                        
+
                         if (!Utilities.GetPlayers().Exists(x => !x.IsBot && !x.IsHLTV))
                         {
                             _CsServer.LoadAndExecuteConfig("warmup.cfg");

--- a/PugSharp/Application.cs
+++ b/PugSharp/Application.cs
@@ -1897,6 +1897,7 @@ public class Application : IApplication
                 {
                     try
                     {
+                        
                         if (!Utilities.GetPlayers().Exists(x => !x.IsBot && !x.IsHLTV))
                         {
                             _CsServer.LoadAndExecuteConfig("warmup.cfg");


### PR DESCRIPTION
Team Mode: Player Select (2)

Idea: Players manually select their team, rather than it being decided by the config (or randomly).

Addresses a lot of the concerns from: https://github.com/Lan2Play/PugSharp/issues/43
However, players are not scrambled, but rather just join the "correct" team.
Alongside the ready-up messages, I display which team they are currently on.

- MatchConfig without Players
- Players can switch teams during startup
- Teams are fixed after the match starts

I had to override some warmup parameters (for 1st map):

sv_disable_teamselect_menu false
sv_human_autojoin_team 0