### PR TITLE
Bump CounterStrikeSharp.API from 1.0.286 to 1.0.294 / Fix CS2 update from 20.12.24

### DIFF
--- a/Docs/source/admin/quickstart.rst
+++ b/Docs/source/admin/quickstart.rst
@@ -5,7 +5,7 @@ Prerequisites
 -------------------------------
 - Linux Dedicated Server
 - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
-- `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_
+- `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_
 - `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  (depending on your selected package, there is no need to install this seperatly)
 - Dotnet Runtime needed by `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ (depending on your selected package, there is no need to install this seperatly)
 
@@ -18,7 +18,7 @@ Prerequisites
    .. Linux - Stable with CounterStrikeSharp and Dotnet Runtime (recommended)
    .. ................................................................................
 
-   .. - Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+   .. - Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
    .. - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
    .. - Download one of our releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ and the Dotnet Runtime named ``PugSharp_with_cssharp_and_runtime_linux_X.X.X.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
    .. - Have fun and report bugs :D
@@ -26,7 +26,7 @@ Prerequisites
    .. Windows - Stable with CounterStrikeSharp and Dotnet Runtime (recommended)
    .. ..............................................................................
 
-   .. - Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+   .. - Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
    .. - Download one of our releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ and the Dotnet Runtime named ``PugSharp_with_cssharp_and_runtime_windows_X.X.X.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
    .. - Have fun and report bugs :D
 
@@ -36,7 +36,7 @@ Prerequisites
    .. .. warning::
    ..    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so. Only use this if you know why you want to do that.
 
-   .. - Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+   .. - Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
    .. - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
    .. - Download one of our releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  named ``PugSharp_with_cssharp_linux_X.X.X.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
    .. - check the ``Add dotnet runtime`` step in `the ci file of CounterStrikeSharp <https://github.com/roflmuffin/CounterStrikeSharp/blob/main/.github/workflows/cmake-single-platform.yml>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the ``aspnetcore-runtime-X.X.X-linux-x64.tar.gz`` linked there. 
@@ -50,7 +50,7 @@ Prerequisites
    .. .. warning::
    ..    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so. Only use this if you know why you want to do that.
 
-   .. - Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+   .. - Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
    .. - Download one of our releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ named ``PugSharp_with_cssharp_windows_X.X.X.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder.
    .. - check the ``Add dotnet runtime`` step in `the ci file of CounterStrikeSharp <https://github.com/roflmuffin/CounterStrikeSharp/blob/main/.github/workflows/cmake-single-platform.yml>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the ``aspnetcore-runtime-X.X.X-win-x64.zip`` linked there. 
    .. - Extract the contents of the dotnet runtime into ``addons/counterstrikesharp/dotnet`` of your csgo server
@@ -63,7 +63,7 @@ Prerequisites
    .. .. warning::
    ..    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so and also update `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  if the version of it that PugSharp depends on changes. Only use this if you know why you want to do that.
 
-   .. - Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+   .. - Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
    .. - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
    .. - Download one of our releases named ``PugSharp_linux_X.X.X.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
    .. - check the ``CounterStrikeSharp.API`` dependency version in `the csproj file of Pugsharp <https://github.com/Lan2Play/PugSharp/blob/main/PugSharp/PugSharp.csproj>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the `CounterStrikeSharp release <https://github.com/roflmuffin/CounterStrikeSharp/releases>`_ that is configured there. 
@@ -80,7 +80,7 @@ Prerequisites
    .. .. warning::
    ..    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so and also update `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  if the version of it that PugSharp depends on changes. Only use this if you know why you want to do that.
 
-   .. - Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+   .. - Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
    .. - Download one of our releases named ``PugSharp_windows_X.X.X.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder.
    .. - check the ``CounterStrikeSharp.API`` dependency version in `the csproj file of Pugsharp <https://github.com/Lan2Play/PugSharp/blob/main/PugSharp/PugSharp.csproj>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the `CounterStrikeSharp release <https://github.com/roflmuffin/CounterStrikeSharp/releases>`_ that is configured there. 
    .. - Extract the contents of the CounterStrikeSharp into the csgo folder of your csgo server
@@ -97,7 +97,7 @@ We have multiple packages depending on your operating system and if you want to 
 Linux - Beta with CounterStrikeSharp and Dotnet Runtime (recommended)
 ................................................................................
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
 - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
 - Download one of our pre-releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ and the Dotnet Runtime named ``PugSharp_with_cssharp_and_runtime_linux_X.X.X-beta.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
 - Have fun and report bugs :D
@@ -105,7 +105,7 @@ Linux - Beta with CounterStrikeSharp and Dotnet Runtime (recommended)
 Windows - Beta with CounterStrikeSharp and Dotnet Runtime (recommended)
 ..............................................................................
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
 - Download one of our pre-releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ and the Dotnet Runtime named ``PugSharp_with_cssharp_and_runtime_windows_X.X.X-beta.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
 - Have fun and report bugs :D
 
@@ -115,7 +115,7 @@ Linux - Beta with CounterStrikeSharp
 .. warning::
    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
 - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
 - Download one of our pre-releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  named ``PugSharp_with_cssharp_linux_X.X.X-beta.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
 - check the ``Add dotnet runtime`` step in `the ci file of CounterStrikeSharp <https://github.com/roflmuffin/CounterStrikeSharp/blob/main/.github/workflows/cmake-single-platform.yml>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the ``aspnetcore-runtime-X.X.X-linux-x64.tar.gz`` linked there. 
@@ -129,7 +129,7 @@ Windows - Beta With CounterStrikeSharp
 .. warning::
    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
 - Download one of our pre-releases including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ named ``PugSharp_with_cssharp_windows_X.X.X-beta.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder.
 - check the ``Add dotnet runtime`` step in `the ci file of CounterStrikeSharp <https://github.com/roflmuffin/CounterStrikeSharp/blob/main/.github/workflows/cmake-single-platform.yml>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the ``aspnetcore-runtime-X.X.X-win-x64.zip`` linked there. 
 - Extract the contents of the dotnet runtime into ``addons/counterstrikesharp/dotnet`` of your csgo server
@@ -142,7 +142,7 @@ Linux Beta
 .. warning::
    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so and also update `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  if the version of it that PugSharp depends on changes. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
 - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
 - Download one of our pre-releases named ``PugSharp_linux_X.X.X-beta.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder. 
 - check the ``CounterStrikeSharp.API`` dependency version in `the csproj file of Pugsharp <https://github.com/Lan2Play/PugSharp/blob/main/PugSharp/PugSharp.csproj>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the `CounterStrikeSharp release <https://github.com/roflmuffin/CounterStrikeSharp/releases>`_ that is configured there. 
@@ -159,7 +159,7 @@ Windows Beta
 .. warning::
     This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so and also update `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  if the version of it that PugSharp depends on changes. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
 - Download one of our pre-releases named ``PugSharp_windows_X.X.X-beta.zip`` from our `releases <https://github.com/Lan2Play/PugSharp/releases>`_ and unpack it to your csgo folder.
 - check the ``CounterStrikeSharp.API`` dependency version in `the csproj file of Pugsharp <https://github.com/Lan2Play/PugSharp/blob/main/PugSharp/PugSharp.csproj>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the `CounterStrikeSharp release <https://github.com/roflmuffin/CounterStrikeSharp/releases>`_ that is configured there. 
 - Extract the contents of the CounterStrikeSharp into the csgo folder of your csgo server
@@ -178,7 +178,7 @@ We have multiple packages depending on your operating system and if you want to 
 Linux - Alpha with CounterStrikeSharp and Dotnet Runtime (recommended)
 ................................................................................
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
 - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
 - Download one of our alphas including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ and the Dotnet Runtime named ``latest_build_linux_with_cssharp_and_runtime`` from our `alpha builds <https://github.com/Lan2Play/PugSharp/actions/workflows/test_and_build.yml>`_ (click on a run, scroll down to artifacts) and unpack the containing ``PugSharp_with_cssharp_and_runtime_linux_X.X.X-alpha.zip`` to your csgo folder. 
 - Have fun and report bugs :D
@@ -186,7 +186,7 @@ Linux - Alpha with CounterStrikeSharp and Dotnet Runtime (recommended)
 Windows - Alpha with CounterStrikeSharp and Dotnet Runtime (recommended)
 ..............................................................................
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
 - Download one of our alphas including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ and the Dotnet Runtime named ``latest_build_windows_with_cssharp_and_runtime`` from our `alpha builds <https://github.com/Lan2Play/PugSharp/actions/workflows/test_and_build.yml>`_ (click on a run, scroll down to artifacts) and unpack the containing ``PugSharp_with_cssharp_and_runtime_windows_X.X.X-alpha.zip`` to your csgo folder. 
 - Have fun and report bugs :D
 
@@ -196,7 +196,7 @@ Linux - Alpha with CounterStrikeSharp
 .. warning::
    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
 - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
 - Download one of our alphas including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  named ``latest_build_linux_with_cssharp`` from our `alpha builds <https://github.com/Lan2Play/PugSharp/actions/workflows/test_and_build.yml>`_ (click on a run, scroll down to artifacts) and unpack the containing ``PugSharp_with_cssharp_linux_X.X.X-alpha.zip`` to your csgo folder. 
 - check the ``Add dotnet runtime`` step in `the ci file of CounterStrikeSharp <https://github.com/roflmuffin/CounterStrikeSharp/blob/main/.github/workflows/cmake-single-platform.yml>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the ``aspnetcore-runtime-X.X.X-linux-x64.tar.gz`` linked there. 
@@ -210,7 +210,7 @@ Windows - Alpha With CounterStrikeSharp
 .. warning::
    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
 - Download one of our alphas including `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ named ``latest_build_windows_with_cssharp`` from our `alpha builds <https://github.com/Lan2Play/PugSharp/actions/workflows/test_and_build.yml>`_ (click on a run, scroll down to artifacts) and unpack the containing ``PugSharp_with_cssharp_windows_X.X.X-alpha.zip`` to your csgo folder.
 - check the ``Add dotnet runtime`` step in `the ci file of CounterStrikeSharp <https://github.com/roflmuffin/CounterStrikeSharp/blob/main/.github/workflows/cmake-single-platform.yml>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the ``aspnetcore-runtime-X.X.X-win-x64.zip`` linked there. 
 - Extract the contents of the dotnet runtime into ``addons/counterstrikesharp/dotnet`` of your csgo server
@@ -223,7 +223,7 @@ Linux Alpha
 .. warning::
    This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so and also update `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  if the version of it that PugSharp depends on changes. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Linux Dedicated Server 
 - ``libicu`` / ``icu-libs`` / ``libicu-dev`` (depending on your distribution) install from your package manager for support of multiple languages
 - Download one of our alphas named ``latest_build_linux`` from our `alpha builds <https://github.com/Lan2Play/PugSharp/actions/workflows/test_and_build.yml>`_ (click on a run, scroll down to artifacts) and unpack the containing ``PugSharp_linux_X.X.X-alpha.zip`` to your csgo folder. 
 - check the ``CounterStrikeSharp.API`` dependency version in `the csproj file of Pugsharp <https://github.com/Lan2Play/PugSharp/blob/main/PugSharp/PugSharp.csproj>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the `CounterStrikeSharp release <https://github.com/roflmuffin/CounterStrikeSharp/releases>`_ that is configured there. 
@@ -240,7 +240,7 @@ Windows Alpha
 .. warning::
     This method is not recommended, since you have to make sure you update your dotnet runtime yourself, if `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_ does so and also update `CounterStrikeSharp by roflmuffin <https://github.com/roflmuffin/CounterStrikeSharp>`_  if the version of it that PugSharp depends on changes. Only use this if you know why you want to do that.
 
-- Install `MetaMod 2.0 <https://www.sourcemm.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
+- Install `MetaMod 2.0 <https://www.metamodsource.net/downloads.php?branch=dev>`_ on your Windows Dedicated Server 
 - Download one of our alphas named ``latest_build_linux`` from our `alpha builds <https://github.com/Lan2Play/PugSharp/actions/workflows/test_and_build.yml>`_ (click on a run, scroll down to artifacts) and unpack the containing ``PugSharp_windows_X.X.X-alpha.zip`` to your csgo folder.
 - check the ``CounterStrikeSharp.API`` dependency version in `the csproj file of Pugsharp <https://github.com/Lan2Play/PugSharp/blob/main/PugSharp/PugSharp.csproj>`_ (make sure you use the one from the corresponding release instead the one from the ``main`` branch) and download the `CounterStrikeSharp release <https://github.com/roflmuffin/CounterStrikeSharp/releases>`_ that is configured there. 
 - Extract the contents of the CounterStrikeSharp into the csgo folder of your csgo server

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install-counterstrikesharp:
 install-counterstrikesharp-docker:
 	docker run --rm --interactive \
 	-v $(currentDir):/app \
-	mcr.microsoft.com/dotnet/sdk:7.0 /bin/sh -c " \
+	mcr.microsoft.com/dotnet/sdk:8.0 /bin/sh -c " \
 	apt-get update && apt-get install jq unzip -y; \
 	mkdir -p /app/cs2/game/csgo/addons/; \
 	wget -q -O /app/counterstrikesharp.zip $(shell curl -s -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/roflmuffin/CounterStrikeSharp/releases/tags/$(shell dotnet list PugSharp/PugSharp.csproj package --format json | jq -r '.projects[].frameworks[].topLevelPackages[] | select(.id == "CounterStrikeSharp.API") | .resolvedVersion' | sed 's|1.0.|v|g') | jq -r '.assets.[] | select(.browser_download_url | test("with-runtime.*linux")) | .browser_download_url'); \
@@ -109,18 +109,18 @@ build-release:
 build-debug-docker:
 	docker run --rm --interactive \
 	-v $(currentDir):/app \
-	mcr.microsoft.com/dotnet/sdk:7.0 /bin/sh -c " \
+	mcr.microsoft.com/dotnet/sdk:8.0 /bin/sh -c " \
 	cd /app && dotnet publish -c debug; chown -R $(user) /app"
 
 build-release-docker:
 	docker run --rm --interactive \
 	-v $(currentDir):/app \
-	mcr.microsoft.com/dotnet/sdk:7.0 /bin/sh -c " \
+	mcr.microsoft.com/dotnet/sdk:8.0 /bin/sh -c " \
 	cd /app && dotnet publish -c release; chown -R $(user) /app"
 
 copy-pugsharp:
 	mkdir -p $(currentDir)/cs2/game/csgo/addons/counterstrikesharp/plugins/PugSharp
-	cp -rf $(currentDir)/PugSharp/bin/Debug/net7.0/publish/* $(currentDir)/cs2/game/csgo/addons/counterstrikesharp/plugins/PugSharp
+	cp -rf $(currentDir)/PugSharp/bin/Debug/net8.0/publish/* $(currentDir)/cs2/game/csgo/addons/counterstrikesharp/plugins/PugSharp
 
 copy-pugsharp-sample-configs:
 	mkdir -p $(currentDir)/cs2/game/csgo/cfg

--- a/PugSharp.Tests/PugSharp.Tests.csproj
+++ b/PugSharp.Tests/PugSharp.Tests.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CounterStrikeSharp.API" Version="1.0.286" />
+		<PackageReference Include="CounterStrikeSharp.API" Version="1.0.294" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="xunit" Version="2.9.2" />

--- a/PugSharp/PugSharp.csproj
+++ b/PugSharp/PugSharp.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CounterStrikeSharp.API" Version="1.0.286">
+		<PackageReference Include="CounterStrikeSharp.API" Version="1.0.294">
 			<PrivateAssets>none</PrivateAssets>
 			<ExcludeAssets>runtime</ExcludeAssets>
 			<IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ If you want to know how to use PugSharp, hop over to our [Documentation](https:/
 - Plugin Framework: [CounterStrikeSharp by roflmuffin](https://github.com/roflmuffin/CounterStrikeSharp)
 - Docker test setup: [joedwards32/cs2](https://github.com/joedwards32/CS2)
 - Metamod fix script: [ghostcap-gaming/cs2-metamod-re-enable-script](https://github.com/ghostcap-gaming/cs2-metamod-re-enable-script)
-- Metamod: https://www.sourcemm.net/
+- Metamod: https://www.metamodsource.net/
 - Version detection stolen (and modified) with permission from [CS2-AutoUpdater](https://github.com/dran1x/CS2-AutoUpdater)
 


### PR DESCRIPTION
Bump CounterStrikeSharp.API from 1.0.286 to 1.0.294 to fix CS2 update from 20.12.24